### PR TITLE
fix: repair terragrunt scaffold boilerplate inputs

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -1,43 +1,28 @@
 ##
-# (c) 2025 - Cloud Ops Works LLC - https://cloudops.works/
-#            On GitHub: https://github.com/cloudopsworks
-#            Distributed Under Apache v2.0 License
+# (c) 2021-2026
+#     Cloud Ops Works LLC - https://cloudops.works/
+#     Find us on:
+#       GitHub: https://github.com/cloudopsworks
+#       WebSite: https://cloudops.works
+#     Distributed Under Apache v2.0 License
 #
+# Terragrunt Boilerplate Configuration
 variables:
   # Generic Boilerplate Variables Setup
-  - name: organization_name
-    order: 0
-    description: "Organization Name"
-    type: string
-    default: "Organization"
-  - name: organization_unit
-    order: 1
-    description: "Organization Unit"
-    type: string
-    default: "Unit"
-  - name: environment_name
-    order: 2
-    description: "Environment Name"
-    type: string
-    default: "DEV"
-  - name: environment_type
-    order: 3
-    description: "Environment Type"
-    type: string
-    default: "Testing"
-  - name: hub_spoke
-    order: 4
-    description: "Hub and Spoke architecture"
-    type: bool
-    default: false
   - name: is_hub
-    order: 5
+    order: 0
     description: "Is this a hub configuration?"
     type: bool
     default: false
   - name: tags
-    order: 6
+    order: 1
     description: "Tags"
     type: map
     default: {}
   # End - Generic Boilerplate Variables Setup
+
+hooks:
+  after:
+    - command: "git"
+      args: ["add", "."]
+      dir: "{{ outputFolder }}"

--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -1,18 +1,137 @@
 # Module configuration
-# Required variables
-{{- range .requiredVariables }}
-{{- if ne .Name "org"}}
-# Description {{ .Description }} , Type: {{ .Type }}
-{{ .Name }}: {{ .DefaultValuePlaceholder }}
-{{- end }}
 
-{{- end }}
-# Optional variables
-{{- range .optionalVariables }}
-{{- if ne .Name "is_hub" "spoke_def" "extra_args" }}
-# Description {{ .Description }} , Type: {{ .Type }}
-#{{ .Name }}: {{ .DefaultValue }}
-{{- end }}
+name: "" # (Optional) Exact S3 bucket name. Conflicts with name_prefix. Set either name or name_prefix. Default: "".
+name_prefix: "" # (Optional) Prefix used to build the bucket name with the system naming convention. Conflicts with name. Set either name_prefix or name. Default: "".
+random_bucket_suffix: true # (Optional) Appends a random 8-character suffix to the generated bucket name. Set false for deterministic names. Default: true.
+short_system_name: false # (Optional) Uses the short system name in generated bucket names instead of the full system name. Default: false.
+bucket_config: {} # (Optional) S3 bucket settings object. Default: {}. Uncomment and tailor the reference block below as needed.
 
-{{- end }}
-
+# bucket_config:
+#   acl: private # (Optional) Canned ACL to apply to the bucket. Valid values: private, public-read, public-read-write, authenticated-read, log-delivery-write. Default: private.
+#   control_object_ownership: true # (Optional) Manages S3 Object Ownership controls for the bucket. Default: true.
+#   object_ownership: ObjectWriter # (Optional) Object ownership mode. Valid values: ObjectWriter, BucketOwnerPreferred, BucketOwnerEnforced. Default: ObjectWriter.
+#   force_destroy: false # (Optional) Deletes the bucket even when it contains objects. Default: false.
+#
+#   policies: # (Optional) Generated bucket policy toggles. Default: {}.
+#     elb_logs: false # (Optional) Allows classic ELB log delivery to this bucket. Default: false.
+#     lb_logs: false # (Optional) Allows ALB/NLB log delivery to this bucket. Default: false.
+#     access_logs: false # (Optional) Allows S3 server access log delivery to this bucket. Default: false.
+#     access_logs_accounts: [] # (Optional) Additional AWS account IDs allowed to deliver access logs. Default: [].
+#     access_logs_buckets: [] # (Optional) Additional source bucket ARNs allowed to deliver access logs. Default: [].
+#     deny_insecure_transport: true # (Optional) Denies requests that do not use TLS/HTTPS. Default: true.
+#     deny_incorrect_encryption: false # (Optional) Denies uploads that use the wrong SSE algorithm. Default: false.
+#     deny_incorrect_kms_key: false # (Optional) Denies uploads that use the wrong KMS key. Default: false.
+#     deny_ssec_encrypted_uploads: false # (Optional) Denies uploads encrypted with customer-provided keys (SSE-C). Default: false.
+#     deny_unencrypted_uploads: false # (Optional) Denies uploads without server-side encryption. Default: false.
+#     waf_logs: false # (Optional) Allows AWS WAF log delivery to this bucket. Default: false.
+#     cloudtrail_logs: false # (Optional) Allows CloudTrail log delivery to this bucket. Default: false.
+#     analytics_destination: false # (Optional) Allows S3 Analytics export delivery to this bucket. Default: false.
+#     require_latest_tls: true # (Optional) Enforces the latest TLS policy supported by the module. Default: true.
+#     attach_public: true # (Optional) Attaches the public policy document when required by the upstream module. Default: true.
+#
+#   acls: # (Optional) Public access block controls. Default: {}.
+#     blocks_public: true # (Optional) Blocks new public ACLs. Default: true.
+#     blocks_public_policy: true # (Optional) Blocks new public bucket policies. Default: true.
+#     ignore_public_acls: true # (Optional) Ignores existing public ACLs. Default: true.
+#     restrict_public_buckets: true # (Optional) Restricts access to buckets with public policies. Default: true.
+#
+#   server_side_encryption_configuration: # (Optional) Default server-side encryption settings. Default: {}.
+#     rule:
+#       apply_server_side_encryption_by_default:
+#         sse_algorithm: AES256 # (Optional) Default encryption algorithm. Valid values: AES256, aws:kms.
+#         kms_master_key_id: arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000 # (Optional) KMS key ARN or ID when sse_algorithm is aws:kms. Default: null.
+#
+#   policy: "" # (Optional) Raw JSON bucket policy to attach. Use {{bucket_name}} as a placeholder for the final bucket name. Default: "".
+#
+#   website: # (Optional) Static website hosting configuration. Default: {}.
+#     index_document: index.html # (Optional) Index document served by the website endpoint. Default: index.html.
+#     error_document: error.html # (Optional) Error document served by the website endpoint. Default: error.html.
+#     redirect_all_requests_to: # (Optional) Redirects all requests to another host/protocol. Default: null.
+#       host_name: docs.example.com # (Optional) Redirect target host name.
+#       protocol: https # (Optional) Redirect target protocol. Valid values: http, https.
+#     routing_rules: # (Optional) Website routing rules. Default: [].
+#       - condition: # (Optional) Condition that triggers the redirect.
+#           http_error_code_returned_equals: "404" # (Optional) HTTP error code that triggers the redirect.
+#           key_prefix_equals: docs/ # (Optional) Key prefix that triggers the redirect.
+#         redirect:
+#           host_name: static.example.com # (Required) Redirect target host name.
+#           protocol: https # (Optional) Redirect target protocol. Valid values: http, https.
+#           http_redirect_code: "301" # (Optional) HTTP redirect code returned by S3.
+#           replace_key_prefix_with: public/ # (Optional) Replaces the matching prefix in the object key.
+#           replace_key_with: index.html # (Optional) Replaces the object key entirely.
+#
+#   versioning: false # (Optional) Enables bucket versioning when true. Default: false.
+#   versioning_config: # (Optional) Advanced versioning settings merged with versioning. Default: {}.
+#     mfa: arn:aws:iam::123456789012:mfa/admin 123456 # (Optional) MFA device ARN and current token for MFA delete operations. Default: null.
+#     status: Enabled # (Optional) Explicit versioning status. Valid values: Enabled, Suspended. Default: derived from versioning.
+#     mfa_delete: Disabled # (Optional) MFA delete state. Valid values: Enabled, Disabled. Default: Disabled.
+#
+#   lifecycle_rule: # (Optional) Object lifecycle management rules. Default: [].
+#     - id: transition-to-ia # (Optional) Lifecycle rule identifier.
+#       enabled: true # (Optional) Legacy enable flag supported by the upstream module. Default: true.
+#       status: true # (Optional) Enables the lifecycle rule when true. Default: true.
+#       abort_incomplete_multipart_upload_days: 7 # (Optional) Aborts incomplete multipart uploads after the specified days. Default: null.
+#       expiration: # (Optional) Expiration policy for current objects. Default: null.
+#         date: "2026-12-31" # (Optional) Absolute expiration date in YYYY-MM-DD format.
+#         days: 90 # (Optional) Days after object creation before expiration.
+#         expired_object_delete_marker: false # (Optional) Removes expired delete markers. Default: false.
+#       transition: # (Optional) Transition rules for current objects. Default: [].
+#         - date: "2026-06-30" # (Optional) Absolute transition date in YYYY-MM-DD format.
+#           days: 30 # (Optional) Days after object creation before transition.
+#           storage_class: STANDARD_IA # (Optional) Transition target storage class. Valid values: GLACIER, DEEP_ARCHIVE, INTELLIGENT_TIERING, ONEZONE_IA, STANDARD_IA, STANDARD.
+#       noncurrent_version_expiration: # (Optional) Expiration policy for noncurrent object versions. Default: null.
+#         days: 30 # (Optional) Days to retain noncurrent versions.
+#         newer_noncurrent_versions: 5 # (Optional) Number of newer noncurrent versions to retain.
+#       noncurrent_version_transition: # (Optional) Transition rules for noncurrent object versions. Default: [].
+#         - days: 30 # (Optional) Days to wait before transition.
+#           newer_noncurrent_versions: 5 # (Optional) Number of newer versions to retain before transition.
+#           storage_class: GLACIER # (Optional) Transition target storage class. Valid values: GLACIER, DEEP_ARCHIVE, INTELLIGENT_TIERING, ONEZONE_IA, STANDARD_IA, STANDARD.
+#       filter: # (Optional) Filter that scopes the lifecycle rule. Default: null.
+#         prefix: logs/ # (Optional) Applies the rule only to objects with this prefix.
+#         object_size_greater_than: 1048576 # (Optional) Applies only to objects larger than this size in bytes.
+#         object_size_less_than: 1073741824 # (Optional) Applies only to objects smaller than this size in bytes.
+#         tags: # (Optional) Tag filter map. Default: {}.
+#           data_classification: archive # (Optional) Example tag filter entry.
+#
+#   transition_default_minimum_object_size: null # (Optional) Minimum object size, in bytes, eligible for transition actions. Default: null.
+#
+#   object_lock: # (Optional) S3 Object Lock configuration. Default: {}.
+#     enabled: false # (Optional) Enables Object Lock for the bucket. Default: false.
+#     configuration: # (Optional) Default retention policy. Default: {}.
+#       rule:
+#         default_retention:
+#           mode: COMPLIANCE # (Optional) Retention mode. Valid values: COMPLIANCE, GOVERNANCE.
+#           days: 90 # (Optional) Default retention period in days. Set either days or years.
+#           years: null # (Optional) Default retention period in years. Set either years or days.
+#
+#   replication: # (Optional) Cross-region/account replication settings. Default: {}.
+#     role: arn:aws:iam::123456789012:role/s3-replication-role # (Required) IAM role ARN assumed by S3 for replication.
+#     rules: # (Required) Replication rules. Default: [].
+#       - id: replicate-critical-data # (Required) Replication rule identifier.
+#         status: true # (Required) Enables the replication rule when true.
+#         delete_marker_replication: true # (Optional) Replicates delete markers when true. Default: null.
+#         destination: # (Required) Replication destination settings.
+#           bucket: arn:aws:s3:::destination-bucket # (Required) Destination bucket ARN.
+#           storage_class: STANDARD_IA # (Optional) Destination storage class. Valid values: GLACIER, DEEP_ARCHIVE, INTELLIGENT_TIERING, ONEZONE_IA, STANDARD_IA, STANDARD.
+#           account: "123456789012" # (Optional) Destination AWS account ID.
+#           access_control_translation: # (Optional) Ownership translation settings. Default: null.
+#             owner: BucketOwner # (Optional) Required value when access control translation is enabled.
+#           encryption_configuration: # (Optional) Replica encryption settings. Default: null.
+#             replica_kms_key_id: arn:aws:kms:us-east-1:123456789012:key/11111111-1111-1111-1111-111111111111 # (Optional) KMS key ARN for replicated objects.
+#           replication_time: # (Optional) S3 Replication Time Control settings. Default: null.
+#             status: true # (Required) Enables replication time control when true.
+#             minutes: 15 # (Required) Target replication time in minutes.
+#           metrics: # (Optional) Replication metrics settings. Default: null.
+#             status: true # (Required) Enables replication metrics when true.
+#             minutes: 15 # (Required) Event threshold in minutes.
+#         source_selection_criteria: # (Optional) Source object selection rules. Default: null.
+#           replica_modifications: # (Optional) Replicates metadata changes to replicas. Default: null.
+#             enabled: true # (Optional) Enables replica modifications sync. Default: false.
+#           sse_kms_encrypted_objects: # (Optional) Restricts replication to KMS-encrypted objects. Default: null.
+#             enabled: true # (Optional) Enables replication for SSE-KMS encrypted objects. Default: false.
+#         filter: # (Optional) Filter that scopes the replication rule. Default: null.
+#           prefix: critical/ # (Optional) Applies the rule only to objects with this prefix.
+#           tags: # (Optional) Tag filter map. Default: {}.
+#             replication: enabled # (Optional) Example tag filter entry.
+#
+#   tags: {} # (Optional) Additional tags merged only into this bucket's tags. Default: {}.

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -1,5 +1,4 @@
 locals {
-  {{- if .hub_spoke }}
   local_vars  = yamldecode(file("./inputs.yaml"))
   spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
   region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
@@ -19,21 +18,10 @@ locals {
     local.spoke_tags,
     local.local_tags
   )
-  {{- else }}
-  local_vars  = yamldecode(file("./inputs.yaml"))
-  global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
-  global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
-  local_tags  = jsondecode(file("./local-tags.json"))
-
-  tags = merge(
-    local.global_tags,
-    local.local_tags
-  )
-  {{- end }}
 }
 
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path = find_in_parent_folders("{{ .RootFileName }}")
 }
 
 terraform {
@@ -41,27 +29,16 @@ terraform {
 }
 
 inputs = {
-  # org = {
-  #   organization_name = local.env_vars.org.organization_name
-  #   organization_unit = local.env_vars.org.organization_unit
-  #   environment_name  = local.env_vars.org.environment_name
-  #   environment_type  = local.env_vars.org.environment_type
-  # }
-  org = local.env_vars.org
-  {{- if .hub_spoke }}
-  is_hub = {{ .is_hub }}
-  spoke_def = local.spoke_vars.spoke_def
-  {{- end}}
-  ## Required
+  is_hub     = {{ .is_hub }}
+  org        = local.env_vars.org
+  spoke_def  = local.spoke_vars.spoke
   {{- range .requiredVariables }}
   {{- if ne .Name "org" }}
-  {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
+  {{ .Name }} = local.local_vars.{{ .Name }}
   {{- end }}
   {{- end }}
-
-  ## Optional
   {{- range .optionalVariables }}
-  {{- if ne .Name "extra_tags" "is_hub" "spoke_def" "org" }}
+  {{- if not (eq .Name "extra_tags" "is_hub" "spoke_def" "org") }}
   {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
   {{- end }}
   {{- end }}


### PR DESCRIPTION
## Summary

- restore `.boilerplate/inputs.yaml` as a module-specific scaffold template instead of a generic loop stub
- keep scaffolded Terragrunt wiring aligned with hierarchy-supplied `org`, `spoke`, and tag inputs
- ship the boilerplate refresh as a patch-level hotfix

## Validation

- `git diff --check`
- Ruby YAML parse of `.boilerplate/inputs.yaml`
- Confirmed scaffold input keys: `name`, `name_prefix`, `random_bucket_suffix`, `short_system_name`, `bucket_config`
- `make fmt` / `make lint` blocked by local OpenTofu install issues in this environment

+semver: patch