### PR TITLE
chore: add confirm prompts to boilerplate scaffold variables

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -14,11 +14,13 @@ variables:
     description: "Is this a hub configuration?"
     type: bool
     default: false
+    confirm: true
   - name: tags
     order: 1
     description: "Tags"
     type: map
     default: {}
+    confirm: true
   # End - Generic Boilerplate Variables Setup
 
 hooks:


### PR DESCRIPTION
## Summary

- Add `confirm: true` to `is_hub` variable in `.boilerplate/boilerplate.yml`
- Add `confirm: true` to `tags` variable in `.boilerplate/boilerplate.yml`
- Improves scaffolding UX by prompting user confirmation for critical deployment variables during `terragrunt scaffold`

+semver: patch